### PR TITLE
Addition of ID and Class to Form Params

### DIFF
--- a/email_form/pi.email_form.php
+++ b/email_form/pi.email_form.php
@@ -28,6 +28,8 @@ class Plugin_email_form extends Plugin {
     $options['msg_header'] = $this->fetch_param('msg_header', 'New Message');
     $options['msg_footer'] = $this->fetch_param('msg_footer', '');
     $options['subject'] = $this->fetch_param('subject', 'Email Form');
+    $options['class'] = $this->fetch_param('class', '');
+    $options['id'] = $this->fetch_param('id', '');
     
     $required = $this->fetch_param('required');
     $honeypot = $this->fetch_param('honeypot', false, false, true); #boolen param
@@ -48,7 +50,18 @@ class Plugin_email_form extends Plugin {
     }
 
     // Display the form on the page.
-    $output .= '<form method="post">';
+    $output .= '<form method="post"';
+    
+    if( $options['class'] != '') {
+      $output .= ' class="' . $options['class'] . '"';
+    }
+
+    if( $options['id'] != '') {
+      $output .= ' id="' . $options['id'] . '"';
+    }
+
+    $output .= '>';
+    
     $output .= $this->parse_loop($this->content, $vars);
 
     //inject the honeypot if true

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,9 @@ The `{{ email_form }}` tag accepts the following paramaters:
 * **to**: The form recipient's email address.
 * **cc**: A cc email address.
 * **bcc**: A bcc email address.
-* **required**: A pipe seperated list of required fields. Example: "name|address|city". Currently this only does simple validation to check if it is an empty value.
+* **required**: A pipe separated list of required fields. Example: "name|address|city". Currently this only does simple validation to check if it is an empty value.
+* **class**: Apply a class to the form
+* **id**: Apply an ID to the form
 
 ## Issues / Gotchas - On the radar
 


### PR DESCRIPTION
Added in Class and ID to form parameters. Updated docs

``` php
{{ email_form subject="Contact Form" to="handsome@example.com" required="name" class="form-inline" id="sample"}}
```
