### PR TITLE
Do not force Message Header, Message Footer and Subject to lowercase

### DIFF
--- a/email_form/pi.email_form.php
+++ b/email_form/pi.email_form.php
@@ -25,9 +25,9 @@ class Plugin_email_form extends Plugin {
     $options['cc'] = $this->fetch_param('cc', '');
     $options['bcc'] = $this->fetch_param('bcc', '');
     $options['from'] = $this->fetch_param('from', '');
-    $options['msg_header'] = $this->fetch_param('msg_header', 'New Message');
+    $options['msg_header'] = $this->fetch_param('msg_header', 'New Message', false, false, false);
     $options['msg_footer'] = $this->fetch_param('msg_footer', '');
-    $options['subject'] = $this->fetch_param('subject', 'Email Form');
+    $options['subject'] = $this->fetch_param('subject', 'Email Form', false, false, false);
     $options['class'] = $this->fetch_param('class', '');
     $options['id'] = $this->fetch_param('id', '');
     

--- a/email_form/pi.email_form.php
+++ b/email_form/pi.email_form.php
@@ -26,7 +26,7 @@ class Plugin_email_form extends Plugin {
     $options['bcc'] = $this->fetch_param('bcc', '');
     $options['from'] = $this->fetch_param('from', '');
     $options['msg_header'] = $this->fetch_param('msg_header', 'New Message', false, false, false);
-    $options['msg_footer'] = $this->fetch_param('msg_footer', '');
+    $options['msg_footer'] = $this->fetch_param('msg_footer', '', false, false, false);
     $options['subject'] = $this->fetch_param('subject', 'Email Form', false, false, false);
     $options['class'] = $this->fetch_param('class', '');
     $options['id'] = $this->fetch_param('id', '');


### PR DESCRIPTION
Suggestion to stop Message Header, Footer and Subject from being forced to lowercase, using additional parameters as suggested:

http://support.statamic.com/discussions/general-questions-best-practices/615-passing-string-to-add-on-unaltered
