### PR TITLE
Adding a simple is_array check to the input.

### DIFF
--- a/email_form/pi.email_form.php
+++ b/email_form/pi.email_form.php
@@ -125,6 +125,15 @@ class Plugin_email_form extends Plugin {
     $message = $options['msg_header']."\r\n";
     $message .= "-------------\r\n";
     foreach ($input as $key => $value) {
+        // Checking to see if the value happes to be an array.
+        // For example, on a Multiselect you need to pass
+        // the post as an array to get all the selected options.
+        // If it is an array, it will squish it down to a comma-
+        // separated list
+        if( is_array($value) )
+        {
+            $value = implode(', ', $value);
+        }
       $message .= $key.": ".$value."\r\n";
     }
     $message .= "-------------\r\n";


### PR DESCRIPTION
In order to submit a multiselect, or group of checkboxes, the input name needs to be name="somename[]". The form parser was choking on this. So I added a simple conditional to squish the array down to a comma-separated string.

Signed-off-by: Jesse Schutt jesse@trinity-studios.com
